### PR TITLE
fix: ci-api-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,8 @@ jobs:
             sleep 5;
           done
 
-      - name: Run API Tests on Runner
-        run: npm run test:api
-        working-directory: ./backend
+      - name: Run API Tests in Docker
+        run: docker compose -f docker-compose.ci.yml run --rm test-runner
         
       - name: Shutdown Docker Services
         if: always()


### PR DESCRIPTION
… db` error. This was happening because they were being run directly on the GitHub Actions runner, where the `db` service was not available at that hostname.

To fix this, I have modified the CI pipeline to execute the API tests inside the `test-runner` Docker container. In that environment, the `db` service is correctly resolved. This is done by using `docker compose run` to start the `test-runner` service defined in `docker-compose.ci.yml`.