### PR TITLE
Fix(sonar): Resolve double indexing of test files

### DIFF
--- a/backend/sonar-project.properties
+++ b/backend/sonar-project.properties
@@ -10,8 +10,8 @@ sonar.projectName=turnier-app
 # Pfad zum TypeScript-Quellcode, der analysiert werden soll
 sonar.sources=src
 
-# Pfad zu den Testdateien (diese werden anders behandelt)
-sonar.tests=src/__tests__
+# Muster zur Erkennung von Testdateien
+sonar.test.inclusions=src/__tests__/**/*
 
 # Kodierung der Quelldateien
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
The file `src/__tests__/api.spec.ts` was being indexed twice by SonarCloud, once as a main file and once as a test file. This was caused by `sonar.sources` including the `src/__tests__` directory, which was also specified in `sonar.tests`.

This change resolves the issue by using `sonar.test.inclusions` to specify the pattern for test files. This ensures that the sets of main and test files are disjoint, as required by SonarCloud.