### PR TITLE
Fix: Add aggregated coverage reporting for SonarCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,12 @@ jobs:
       - name: Run Backend Unit Tests
         run: npm test
         working-directory: ./backend
- 
+      - name: Upload Unit Test Coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-coverage
+          path: backend/coverage/unit
+
   api-tests:
     needs: lint
     runs-on: ubuntu-latest
@@ -80,7 +85,13 @@ jobs:
 
       - name: Run API Tests in Docker
         run: docker compose -f docker-compose.ci.yml run --rm test-runner
-        
+
+      - name: Upload API Test Coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-test-coverage
+          path: backend/coverage/api
+
       - name: Shutdown Docker Services
         if: always()
         run: docker compose -f docker-compose.ci.yml down
@@ -92,6 +103,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Download Unit Test Coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: unit-test-coverage
+          path: backend/coverage/unit
+      - name: Download API Test Coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: api-test-coverage
+          path: backend/coverage/api
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v2
         env:

--- a/backend/jest.config.api.js
+++ b/backend/jest.config.api.js
@@ -4,4 +4,7 @@ module.exports = {
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/api.spec.ts'],
   setupFiles: ['dotenv/config'],
+  collectCoverage: true,
+  coverageReporters: ['lcov', 'text'],
+  coverageDirectory: 'coverage/api',
 };

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -3,4 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.spec.ts', '!**/__tests__/api.spec.ts'],
+  collectCoverage: true,
+  coverageReporters: ['lcov', 'text'],
+  coverageDirectory: 'coverage/unit',
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,8 +8,8 @@
     "start": "node dist/server.js",
     "build": "tsc",
     "dev": "ts-node src/server.ts",
-    "test": "jest --config jest.config.js",
-    "test:api": "node --max-old-space-size=4096 ./node_modules/.bin/jest --config jest.config.api.js --runInBand",
+    "test": "jest --config jest.config.js --coverage",
+    "test:api": "node --max-old-space-size=4096 ./node_modules/.bin/jest --config jest.config.api.js --runInBand --coverage",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write ."
   },

--- a/backend/sonar-project.properties
+++ b/backend/sonar-project.properties
@@ -15,3 +15,6 @@ sonar.test.inclusions=src/__tests__/**/*
 
 # Kodierung der Quelldateien
 sonar.sourceEncoding=UTF-8
+
+# Pfad zu den LCOV-Reports
+sonar.javascript.lcov.reportPaths=coverage/unit/lcov.info,coverage/api/lcov.info

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -5,6 +5,8 @@ services:
       dockerfile: Dockerfile.test
     env_file:
       - ./.env
+    volumes:
+      - ./backend/coverage:/usr/src/app/coverage
     networks:
       - turnier-netzwerk
     depends_on:


### PR DESCRIPTION
This commit introduces a comprehensive solution for coverage reporting to SonarCloud.

- Fixes the SonarCloud indexing error by using `sonar.test.inclusions`.
- Configures Jest to generate separate coverage reports for unit and API tests.
- Updates `package.json` scripts to run tests with coverage.
- Configures SonarCloud to aggregate both coverage reports.
- Updates the CI/CD pipeline to handle the coverage reports as artifacts, ensuring they are available for the SonarCloud analysis.