### PR TITLE
fix(frontend): associate form labels with controls

### DIFF
--- a/frontend/src/components/RichTextEditor.vue
+++ b/frontend/src/components/RichTextEditor.vue
@@ -49,6 +49,7 @@
       </button>
     </div>
     <div
+      :id="id"
       ref="editor"
       class="p-3 min-h-[100px] bg-white dark:bg-gray-800 rounded-b-lg focus:outline-none"
       contenteditable="true"
@@ -62,6 +63,7 @@ import { ref, onMounted, watch } from 'vue';
 
 const props = defineProps<{
   modelValue?: string;
+  id?: string;
 }>();
 
 const emit = defineEmits(['update:modelValue']);

--- a/frontend/src/components/TeamSetup.vue
+++ b/frontend/src/components/TeamSetup.vue
@@ -13,10 +13,12 @@
       >
         <div class="mb-4">
           <label
+            :for="`group-name-${index}`"
             class="block mb-2 text-sm font-medium text-gray-900 dark:text-white"
             >Gruppenname (optional)</label
           >
           <input
+            :id="`group-name-${index}`"
             v-model="group.name"
             type="text"
             class="group-name-input bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600"

--- a/frontend/src/components/TournamentConfig.vue
+++ b/frontend/src/components/TournamentConfig.vue
@@ -21,7 +21,9 @@
       </div>
 
       <div class="md:col-span-2">
-        <label class="block mb-2 text-sm font-medium"
+        <label
+          for="tournament-image-upload"
+          class="block mb-2 text-sm font-medium"
           >Turnierbild (optional)</label
         >
         <div class="mt-1 flex items-center gap-4">
@@ -85,10 +87,14 @@
 
       <div class="md:col-span-2">
         <label
+          for="description-editor"
           class="block mb-2 text-sm font-medium text-gray-900 dark:text-white"
           >Beschreibung (optional)</label
         >
-        <RichTextEditor v-model="state.config.description" />
+        <RichTextEditor
+          id="description-editor"
+          v-model="state.config.description"
+        />
       </div>
 
       <div


### PR DESCRIPTION
This commit fixes accessibility issues where <label> elements were not associated with their corresponding form controls. This was happening in TeamSetup.vue and TournamentConfig.vue.

- In TeamSetup.vue, added dynamic `for` and `id` attributes to the group name label and input inside the v-for loop.
- In TournamentConfig.vue, associated the 'Turnierbild' and 'Beschreibung' labels with their controls.
- In RichTextEditor.vue, added an `id` prop to allow labels to be associated with the component.