### PR TITLE
fix(ci): Correct version for create-issue action

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,7 +40,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
       - name: Create GitHub Issue on failure
         if: failure() && steps.trivy-scan.outcome == 'failure'
-        uses: actions/create-issue@v5
+        uses: actions/create-issue@v4
         with:
           title: '🛡️ Sicherheits-Scan fehlgeschlagen für ${{ matrix.project }}'
           body: |


### PR DESCRIPTION
The security-scan.yml workflow was failing because it was trying to use version `v5` of the `actions/create-issue` action, which does not exist.

This change corrects the version to `v4`, which is a valid and stable version of the action. This will allow the workflow to run successfully and create issues for security vulnerabilities as intended.