### PR TITLE
fix(ci): Use issues-helper to create issues

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,12 +40,14 @@ jobs:
           severity: 'CRITICAL,HIGH'
       - name: Create GitHub Issue on failure
         if: failure() && steps.trivy-scan.outcome == 'failure'
-        uses: actions/create-issue@v4
+        uses: actions-cool/issues-helper@v3
         with:
+          actions: 'create-issue'
+          token: ${{ secrets.GITHUB_TOKEN }}
           title: '🛡️ Sicherheits-Scan fehlgeschlagen für ${{ matrix.project }}'
           body: |
             Der automatische Trivy-Scan hat eine oder mehrere kritische/hohe Schwachstellen im Docker-Image für **${{ matrix.project }}** (Tag: `latest`) gefunden.
             Bitte überprüfen Sie die Details unten und aktualisieren Sie die betroffenen Abhängigkeiten.
             ### Scan-Ergebnisse
             ${{ steps.trivy-scan.outputs.result }}
-          labels: security, vulnerability
+          labels: security,vulnerability

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,7 +40,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
       - name: Create GitHub Issue on failure
         if: failure() && steps.trivy-scan.outcome == 'failure'
-        uses: actions/create-issue@v5
+        uses: actions/create-issue@v4
         with:
           title: '🛡️ Sicherheits-Scan fehlgeschlagen für ${{ matrix.project }}'
           body: |


### PR DESCRIPTION
The security-scan.yml workflow was failing because it was trying to use a non-existent version of the `actions/create-issue` action.

This change replaces the `create-issue` action with the `actions-cool/issues-helper@v3` action. This provides a more robust and flexible way to create issues.