### PR TITLE
fix(tournament): Use for-of loop for simple iteration

### DIFF
--- a/backend/src/domain/tournament.ts
+++ b/backend/src/domain/tournament.ts
@@ -162,8 +162,7 @@ export class Tournament {
         const team1 = unpairedTeams[0];
         const remainingTeams = unpairedTeams.slice(1);
 
-        for (let i = 0; i < remainingTeams.length; i++) {
-            const team2 = remainingTeams[i];
+        for (const team2 of remainingTeams) {
             if (!team1.opponents.includes(team2.id)) {
                 const nextUnpairedTeams = remainingTeams.filter(t => t.id !== team2.id);
                 const result = this.solvePairings(nextUnpairedTeams);


### PR DESCRIPTION
Refactored the for loop in 'solvePairings' to a for-of loop to comply with the typescript:S4138 rule, improving code readability and adhering to modern iteration practices.