### PR TITLE
fix(health): log error in health check controller

### DIFF
--- a/backend/src/interfaces/healthController.ts
+++ b/backend/src/interfaces/healthController.ts
@@ -8,6 +8,7 @@ healthRouter.get('/', async (req: Request, res: Response) => {
         await pool.query('SELECT 1');
         res.status(200).json({ status: 'ok', database: 'connected' });
     } catch (err) {
+        console.error('Health check failed:', err);
         res.status(503).json({ status: 'error', database: 'disconnected' });
     }
 });


### PR DESCRIPTION
The health check controller was catching database errors and returning a 503 status, but it was not logging the actual error. This made it difficult to debug connection issues.

This change adds a `console.error` statement to the catch block to log the error, addressing the 'typescript:S2486' warning without altering the endpoint's behavior.