### PR TITLE
refactor(frontend): Replace div with fieldset for accessibility

### DIFF
--- a/frontend/src/components/TournamentView.vue
+++ b/frontend/src/components/TournamentView.vue
@@ -107,7 +107,8 @@
     </div>
 
     <div id="view-mode-toggle" class="flex justify-center mb-6">
-      <div class="inline-flex rounded-md shadow-sm" role="group">
+      <fieldset class="inline-flex rounded-md shadow-sm">
+        <legend class="sr-only">Ansichtsmodus für Spiele</legend>
         <button
           type="button"
           class="view-mode-btn px-4 py-2 text-sm font-medium"
@@ -124,7 +125,7 @@
         >
           Chronologisch
         </button>
-      </div>
+      </fieldset>
     </div>
 
     <MatchList />


### PR DESCRIPTION
Replaced a div with role="group" with a fieldset element in TournamentView.vue to improve accessibility. This change addresses the Sonar rule S6819, which recommends using native HTML elements over ARIA roles for better cross-device support.

A visually hidden legend was added to the fieldset to provide a proper accessible name for the button group.