### PR TITLE
fix(frontend): Use RegExp.exec() instead of String.match()

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -10,8 +10,8 @@ async function initializeApp() {
   const hostRegex = /^\/host\/event\/([a-zA-Z0-9-]+)/;
   const viewRegex = /^\/event\/([a-zA-Z0-9-]+)/;
 
-  const hostMatch = path.match(hostRegex);
-  const viewMatch = path.match(viewRegex);
+  const hostMatch = hostRegex.exec(path);
+  const viewMatch = viewRegex.exec(path);
 
   let tournamentId: string | null = null;
   let isReadOnly = false;


### PR DESCRIPTION
Replaced String.match() with RegExp.exec() in main.ts to comply with SonarQube rule typescript:S6594.