### PR TITLE
fix(ci): adapt release actions path filters

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,12 @@ jobs:
       with:
         filters: |
           frontend:
-            - 'frontend/src/**'
+            - 'frontend/**'
+            - '!frontend/src/tests/**'
+            - '!frontend/src/components/tests/**'
           backend:
-            - 'backend/src/**'
+            - 'backend/**'
+            - '!backend/src/__tests__/**'
 
   release-frontend:
     needs: changes


### PR DESCRIPTION
The release actions were triggered for changes in test files. This change adapts the path filters to exclude test folders from triggering a release.

The filters for both frontend and backend now include all files in their respective directories, except for the test directories.